### PR TITLE
Legacy support. Ensure get('id') always returns an integer, even if u…

### DIFF
--- a/src/User/User.php
+++ b/src/User/User.php
@@ -402,6 +402,13 @@ class User extends \Hubzero\Database\Relational
 			$key = 'id';
 		}
 
+		// Legacy code expects get('id') to always
+		// return an integer, even if user is logged out
+		if ($key == 'id' && is_null($default))
+		{
+			$default = 0;
+		}
+
 		return parent::get($key, $default);
 	}
 


### PR DESCRIPTION
…ser is logged out.