### PR TITLE
'itemid' does not appear to be a field in use any longer, and thus…

### DIFF
--- a/src/Bank/MarketHistory.php
+++ b/src/Bank/MarketHistory.php
@@ -78,7 +78,6 @@ class MarketHistory extends Relational
 	 * @var  array
 	 */
 	protected $rules = array(
-		'itemid'   => 'positive|nonzero',
 		'category' => 'notempty'
 	);
 


### PR DESCRIPTION
…shouldn't be required.  

Nanohub #310932
