### PR TITLE
[HUBZERO][#9098] Limiting ldap_search() to a single result causes a P…

### DIFF
--- a/src/Utility/Ldap.php
+++ b/src/Utility/Ldap.php
@@ -532,7 +532,7 @@ class Ldap
 
 		$reqattr = array('gidNumber','cn','description','memberUid');
 
-		$entry = ldap_search($conn, $dn, $filter, $reqattr, 0, 1, 0);
+		$entry = ldap_search($conn, $dn, $filter, $reqattr, 0, 0, 0);
 		$count = ($entry) ? ldap_count_entries($conn, $entry) : 0;
 
 		// If there was a database entry, but there was no ldap entry, create the ldap entry
@@ -768,7 +768,7 @@ class Ldap
 
 		$reqattr = array('gidNumber','cn');
 
-		$entry = ldap_search($conn, $dn, $filter, $reqattr, 0, 1, 0);
+		$entry = ldap_search($conn, $dn, $filter, $reqattr, 0, 0, 0);
 
 		$count = ldap_count_entries($conn, $entry);
 


### PR DESCRIPTION
…HP warning to be emitted

Requests to LDAP are already done one at a time as far as I can tell - chunking them 1000 at a time from the helper didn't help solve the issue presented in the ticket.  
The error occurs when the LDAP directory contains multiple entries for a single group id (dev.vhub group 3163 for example).  We already only deal with the first entry returned - I don't immediately see an issue with no longer limiting the request to 1 group from the server.