### PR TITLE
Fixed mysql query building issue when an object is used in building a set.

### DIFF
--- a/src/Database/Syntax/Mysql.php
+++ b/src/Database/Syntax/Mysql.php
@@ -589,15 +589,8 @@ class Mysql
 
 		foreach ($this->set as $field => $value)
 		{
-			if (is_object($value))
-			{
-				$updates[] = $this->connection->quoteName($field) . ' = ' . $value->build($this);
-			}
-			else
-			{
-				$updates[] = $this->connection->quoteName($field) . ' = ?';
-				$this->bind(is_string($value) ? trim($value) : $value);
-			}
+			$updates[] = $this->connection->quoteName($field) . ' = ?';
+			$this->bind(is_string($value) ? trim($value) : $value);
 		}
 
 		return 'SET ' . implode(',', $updates);


### PR DESCRIPTION
It seems like the `build` method does not exist in any object that may be put into the database.

This was causing errors when calling update on the com_blog API because of the `Date` object that was trying to be put into the database. This error does not seem to occur on the front end because all of the fields get sent as strings.

This modification makes `buildSet` more closely match how `buildValues` is written. `buildValues` did not have this issue with objects.