### PR TITLE
[API] Don't JSON encode the JSON-P wrapping for wrapped calls

### DIFF
--- a/src/Api/Response.php
+++ b/src/Api/Response.php
@@ -152,6 +152,9 @@ class Response extends BaseResponse
 			case 'application/json':
 				$output .= json_encode($content);
 			break;
+			case 'application/javascript':
+				$output .= $content;
+			break;
 			case 'application/vnd.php.serialized':
 				$output .= serialize($content);
 			break;

--- a/src/Api/Response/JsonpCallable.php
+++ b/src/Api/Response/JsonpCallable.php
@@ -54,9 +54,10 @@ class JsonpCallable extends Middleware
 		// check for presence of callback param
 		// if we have one lets replace response content with a function executing the 
 		// current response content
-		if ($callback = $request->getWord('callback', null))
+		if ($callback = $request->getVar('callback', null))
 		{
-			$response->setContent(sprintf('/**/%s(%s);', $callback, $response->getContent()));
+			$response->headers->set('content-type', 'application/javascript');
+			$response->setContent(sprintf('%s(%s);', $callback, $response->getContent()));
 		}
 
 		// return response


### PR DESCRIPTION
Problem found by Adam involving getting a JSON response wrapped in a function for cross site requests