### PR TITLE
Only scan and load migraiton hooks that are PHP files

### DIFF
--- a/src/Content/Migration.php
+++ b/src/Content/Migration.php
@@ -521,9 +521,15 @@ class Migration
 			if (is_dir($path . DS . 'migrations' . DS . 'hooks'))
 			{
 				$found = [];
-				foreach (array_diff(scandir($path . DS . 'migrations' . DS . 'hooks'), $exclude) as $hook)
+				foreach (glob($path . DS . 'migrations' . DS . 'hooks' . DS . '*.php') as $hook)
 				{
-					$found[] = ['base' => $path . DS . 'migrations' . DS . 'hooks', 'name' => $hook];
+					// We just want the filename, so strip the path off
+					$hook = str_replace($path . DS . 'migrations' . DS . 'hooks' . DS, '', $hook);
+
+					$found[] = [
+						'base' => $path . DS . 'migrations' . DS . 'hooks',
+						'name' => $hook
+					];
 				}
 
 				$hooks = array_merge($hooks, $found);

--- a/src/Form/Fields/Password.php
+++ b/src/Form/Fields/Password.php
@@ -67,14 +67,14 @@ class Password extends Field
 		if ($meter)
 		{
 			Asset::script('system/passwordstrength.js', true, true);
-			$script = '<script type="text/javascript">new Form.PasswordStrength("' . $this->id . '",
-				{
+			$script = '<script type="text/javascript">jQuery(document).ready(function ($) {
+				$("#' . $this->id . '").passwordstrength({
 					threshold: ' . $threshold . ',
 					onUpdate: function(element, strength, threshold) {
 						element.set("data-passwordstrength", strength);
 					}
-				}
-			);</script>';
+				});
+			});</script>';
 		}
 
 		return '<input type="password" name="' . $this->name . '" id="' . $this->id . '"' .


### PR DESCRIPTION
Previous version of code would attempt to load any file found in the `hooks` directory and treat it as a PHP file containing a class. So, even a JS or `something.php.bak` file would attempted to be executed and throw errors. This change only looks for PHP files.