### PR TITLE
When asked to format a number, format 0 as well

### DIFF
--- a/src/Utility/Number.php
+++ b/src/Utility/Number.php
@@ -74,7 +74,7 @@ class Number
 			}
 		}
 
-		return '';
+		return '0 B';
 	}
 
 	/**


### PR DESCRIPTION
Empty string was returned for files of size 0,  a formatted string should always be returned (maybe unless a negative size is asked to be formatted...?)