### PR TITLE
[MYGEOHUB][#1187] Adding missing var declaration

### DIFF
--- a/src/Filesystem/Collection.php
+++ b/src/Filesystem/Collection.php
@@ -301,10 +301,11 @@ class Collection extends ItemList
 		}
 
 		// Get temp directory
-		$adapter = null;
-		$temp    = sys_get_temp_dir();
-		$tarname = uniqid() . '.zip';
-		$zip     = new \ZipArchive;
+		$adapter  = null;
+		$temp     = sys_get_temp_dir();
+		$uniqueId = uniqid();
+		$tarname  = uniqid() . '.zip';
+		$zip      = new \ZipArchive;
 
 		if ($zip->open($temp . DS . $tarname, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) === true)
 		{


### PR DESCRIPTION
`$uniqueId` was used further down int he code but never defined.