### PR TITLE
Adding no-api flag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/hubzero/phpcs-standards"
+            "url": "https://github.com/hubzero/phpcs-standards",
+            "no-api": true
         }
     ],
     "autoload": {


### PR DESCRIPTION
no-api means that it will clone the repo to extract metadata from the git metadata instead of using the github API