### PR TITLE
Remove usage of deprecated Joomla constant

### DIFF
--- a/src/Api/Component/Loader.php
+++ b/src/Api/Component/Loader.php
@@ -67,20 +67,16 @@ class Loader extends Base
 		// Build the component path.
 		$client = (isset($this->app['client']->alias) ? $this->app['client']->alias : $this->app['client']->name);
 
-		// Get component path
-		if (is_dir(PATH_APP . DS . 'components' . DS . $option . DS . $client))
-		{
-			$base = PATH_APP;
-		}
-		else
-		{
-			$base = PATH_CORE;
-		}
-
 		// Set path and constants
-		define('JPATH_COMPONENT', $base . DS . 'components' . DS . $option . DS . $client);
-		define('JPATH_COMPONENT_SITE', $base . DS . 'components' . DS . $option . DS . 'site');
-		define('JPATH_COMPONENT_ADMINISTRATOR', $base . DS . 'components' . DS . $option . DS . 'admin');
+		define('PATH_COMPONENT', $this->path($option) . DIRECTORY_SEPARATOR . $client);
+		define('PATH_COMPONENT_SITE', $this->path($option) . DIRECTORY_SEPARATOR . 'site');
+		define('PATH_COMPONENT_ADMINISTRATOR', $this->path($option) . DIRECTORY_SEPARATOR . 'admin');
+
+		// Legacy compatibility
+		// @TODO: Deprecate this!
+		define('JPATH_COMPONENT', PATH_COMPONENT);
+		define('JPATH_COMPONENT_SITE', PATH_COMPONENT_SITE);
+		define('JPATH_COMPONENT_ADMINISTRATOR', PATH_COMPONENT_ADMINISTRATOR);
 
 		$version    = $this->app['request']->getVar('version');
 		$controller = $this->app['request']->getCmd('controller', 'api');
@@ -89,7 +85,7 @@ class Loader extends Base
 		// recent version from the available controllers
 		if (!$version)
 		{
-			$files = glob(JPATH_COMPONENT . '/controllers/' . $controller . 'v*.php');
+			$files = glob(PATH_COMPONENT . DIRECTORY_SEPARATOR . 'controllers' . DIRECTORY_SEPARATOR . $controller . 'v*.php');
 
 			if (!empty($files))
 			{
@@ -104,7 +100,7 @@ class Loader extends Base
 			$controller .= 'v' . str_replace('.', '_', $version);
 		}
 
-		$path       = JPATH_COMPONENT . DS . 'controllers' . DS . $controller . '.php';
+		$path       = PATH_COMPONENT . DIRECTORY_SEPARATOR . 'controllers' . DIRECTORY_SEPARATOR . $controller . '.php';
 		$controller = '\\Components\\' . ucfirst(substr($option, 4)) . '\\Api\\Controllers\\' . ucfirst($controller);
 		$found      = false;
 
@@ -122,7 +118,7 @@ class Loader extends Base
 			{
 				$found = true;
 
-				$lang->load($option, JPATH_COMPONENT, null, false, true);
+				$lang->load($option, PATH_COMPONENT, null, false, true);
 			}
 		}
 

--- a/src/Component/View.php
+++ b/src/Component/View.php
@@ -61,9 +61,9 @@ class View extends AbstractView
 		{
 			$config['base_path'] = '';
 
-			if (defined('JPATH_COMPONENT'))
+			if (defined('PATH_COMPONENT'))
 			{
-				$config['base_path'] = JPATH_COMPONENT;
+				$config['base_path'] = PATH_COMPONENT;
 			}
 		}
 		$this->_basePath = $config['base_path'];

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -171,9 +171,9 @@ class View extends Obj
 		{
 			$config['base_path'] = '';
 
-			if (defined('JPATH_COMPONENT'))
+			if (defined('PATH_COMPONENT'))
 			{
-				$config['base_path'] = JPATH_COMPONENT;
+				$config['base_path'] = PATH_COMPONENT;
 			}
 		}
 		$this->_basePath = $config['base_path'];
@@ -568,6 +568,13 @@ class View extends Obj
 
 		// Clear out the prior search dirs
 		$this->_path[$type] = array();
+
+		// Add view directories without the '/tmpl' legacy directory
+		if ($type == 'template' && basename($path) == 'tmpl')
+		{
+			// Push to the bottom of the stack
+			$this->addPath($type, dirname($path));
+		}
 
 		// Actually add the user-specified directories
 		$this->addPath($type, $path);


### PR DESCRIPTION
* Changes usage of JPATH_COMPONENT to PATH_COMPONENT and some minor
reworking of the API component loader to reduce redundancy and simplify
some code.
* Allows for finding of views not in `tmpl` subdirectory.