### PR TITLE
Fixing Calendar form field's date format

### DIFF
--- a/src/Form/Fields/Calendar.php
+++ b/src/Form/Fields/Calendar.php
@@ -58,7 +58,7 @@ class Calendar extends Field
 	protected function getInput()
 	{
 		// Initialize some field attributes.
-		$format = $this->element['format'] ? (string) $this->element['format'] : '%Y-%m-%d';
+		$format = $this->element['format'] ? (string) $this->element['format'] : 'yy-mm-dd';
 
 		// Build the attributes array.
 		$attributes = array();
@@ -81,6 +81,11 @@ class Calendar extends Field
 		if ((string) $this->element['disabled'] == 'true')
 		{
 			$attributes['disabled'] = 'disabled';
+		}
+		$attributes['time'] = false;
+		if ((string) $this->element['time'] == 'true')
+		{
+			$attributes['time'] = true;
 		}
 		if ($this->element['onchange'])
 		{

--- a/src/Html/Builder/Input.php
+++ b/src/Html/Builder/Input.php
@@ -174,6 +174,7 @@ class Input
 
 		$readonly = isset($options['readonly']) && $options['readonly'] == 'readonly';
 		$disabled = isset($options['disabled']) && $options['disabled'] == 'disabled';
+		$time     = isset($options['time']) ? (bool)$options['time'] : true;
 
 		$format = 'yy-mm-dd';
 		if (isset($options['format']))
@@ -202,11 +203,17 @@ class Input
 			// Only display the triggers once for each control.
 			if (!in_array($id, $done))
 			{
-				$format = ($format == 'Y-m-d H:i:s' || $format == '%Y-%m-%d %H:%M:%S' || $format == 'Y-m-d' ? 'yy-mm-dd' : $format);
+				if ($format == 'Y-m-d H:i:s' || $format == '%Y-%m-%d %H:%M:%S')
+				{
+					$time = true;
+				}
+				$altformats = array('Y-m-d H:i:s', '%Y-%m-%d %H:%M:%S', 'Y-m-d', '%Y-%m-%d');
+
+				$format = (in_array($format, $altformats) ? 'yy-mm-dd' : $format);
 
 				\App::get('document')->addScriptDeclaration("
 					jQuery(document).ready(function($){
-						$('#" . $id . "').datetimepicker({
+						" . ($time ? "$('#" . $id . "').datetimepicker({" : "$('#" . $id . "').datepicker({") . "
 							duration: '',
 							showTime: true,
 							constrainInput: false,
@@ -214,8 +221,7 @@ class Input
 							stepHours: 1,
 							altTimeField: '',
 							time24h: true,
-							dateFormat: '" . $format . "',
-							timeFormat: 'HH:mm:00'
+							dateFormat: '" . $format . "'" . ($time ? ", timeFormat: 'HH:mm:00'" : "") . "
 						});
 					});
 				");


### PR DESCRIPTION
Fixing the default format for the Calendar form field and making time
(hour and minute slides) an option that can be disabled (date picker vs
datetime picker).