### PR TITLE
Serve user pictures as public files

### DIFF
--- a/src/User/Picture/File.php
+++ b/src/User/Picture/File.php
@@ -106,7 +106,7 @@ class File implements Resolver
 
 		if (file_exists($path))
 		{
-			return with(new Moderator($path))->getUrl();
+			return with(new Moderator($path, 'public'))->getUrl();
 		}
 
 		return '';

--- a/src/User/Picture/Identicon.php
+++ b/src/User/Picture/Identicon.php
@@ -148,7 +148,7 @@ class Identicon implements Resolver
 
 		if (file_exists($path))
 		{
-			return with(new Moderator($path))->getUrl();
+			return with(new Moderator($path, 'public'))->getUrl();
 		}
 
 		$image = $processor->getImageData($email, $size, $this->color);
@@ -164,6 +164,6 @@ class Identicon implements Resolver
 			return sprintf('data:image/png;base64,%s', base64_encode($image));
 		}
 
-		return with(new Moderator($path))->getUrl();
+		return with(new Moderator($path, 'public'))->getUrl();
 	}
 }

--- a/src/User/Picture/Initialcon.php
+++ b/src/User/Picture/Initialcon.php
@@ -148,7 +148,7 @@ class Initialcon implements Resolver
 
 		if (file_exists($path))
 		{
-			return with(new Moderator($path))->getUrl();
+			return with(new Moderator($path, 'public'))->getUrl();
 		}
 
 		// If the name has a space
@@ -181,6 +181,6 @@ class Initialcon implements Resolver
 			return sprintf('data:image/png;base64,%s', base64_encode($image));
 		}
 
-		return with(new Moderator($path))->getUrl();
+		return with(new Moderator($path, 'public'))->getUrl();
 	}
 }

--- a/src/User/Picture/Namedfile.php
+++ b/src/User/Picture/Namedfile.php
@@ -156,7 +156,7 @@ class Namedfile implements Resolver
 
 			if (file_exists($path))
 			{
-				return with(new Moderator($path))->getUrl();
+				return with(new Moderator($path, 'public'))->getUrl();
 			}
 		}
 


### PR DESCRIPTION
This means the link is not tied to a specific session, allowing it to
be used in emails and the image to be cached by the browser.