### PR TITLE
Clear terms from users table

### DIFF
--- a/src/Console/Command/User/Terms.php
+++ b/src/Console/Command/User/Terms.php
@@ -113,10 +113,22 @@ class Terms extends Base implements CommandInterface
 			}
 
 			// Clear all old TOU states
-			$dbo->setQuery("UPDATE `#__xprofiles` SET `usageAgreement`=0;");
-			if (!$dbo->query())
+			if ($dbo->tableExists('#__users') && $dbo->tableHasField('#__users', 'usageAgreement'))
 			{
-				$this->output->error('Unable to clear xprofiles terms of use.');
+				$dbo->setQuery("UPDATE `#__users` SET `usageAgreement`=0;");
+				if (!$dbo->query())
+				{
+					$this->output->error('Unable to clear users terms of use.');
+				}
+			}
+
+			if ($dbo->tableExists('#__xprofiles') && $dbo->tableHasField('#__xprofiles', 'usageAgreement'))
+			{
+				$dbo->setQuery("UPDATE `#__xprofiles` SET `usageAgreement`=0;");
+				if (!$dbo->query())
+				{
+					$this->output->error('Unable to clear xprofiles terms of use.');
+				}
 			}
 
 			// Output message to let admin know everything went well


### PR DESCRIPTION
Clear terms from users as well as xprofiles (deprecated) table. Check
for existence of tables and field on tables first.