### PR TITLE
actually pass the sql statement to setQuery()

### DIFF
--- a/src/Console/Command/Repository/Flavor.php
+++ b/src/Console/Command/Repository/Flavor.php
@@ -109,7 +109,7 @@ class Flavor extends Base implements CommandInterface
 					$welcome_params->set('template', 'hubbasic2013');
 				}
 	                        $query = "UPDATE `#__template_styles` SET `params`=".$database->quote(json_encode($welcome_params->toArray()))." WHERE `template`='welcome';";
-				$database->setQuery();
+				$database->setQuery($query);
 				$database->query();
 
 				$this->output->addLine('Setting amazon flavor flag in welcome template');


### PR DESCRIPTION
A fix I've been manually putting into packages for months.

A previous commit to fix the muse flavorizer failed to actually pass the sql string to setQuery()