### PR TITLE
[refactor] Reducing dependencies and more config options

### DIFF
--- a/providers/LogServiceProvider.php
+++ b/providers/LogServiceProvider.php
@@ -51,20 +51,35 @@ class LogServiceProvider extends ServiceProvider
 	{
 		$this->app['log'] = function($app)
 		{
-			$manager = new Manager($app);
+			$path = $app['config']->get('log_path');
+			if (is_dir('/var/log/hubzero'))
+			{
+				$path = '/var/log/hubzero';
+			}
+
+			$dispatcher = null;
+			if ($app->has('dispatcher'))
+			{
+				$dispatcher = $app['dispatcher'];
+			}
+
+			$manager = new Manager($path);
 
 			$manager->register('debug', array(
-				'file' => 'cmsdebug.log',
+				'file'       => 'cmsdebug.log',
+				'dispatcher' => $dispatcher
 			));
 
 			$manager->register('auth', array(
-				'file'   => 'cmsauth.log',
-				'level'  => 'info',
-				'format' => "%datetime% %message%\n",
+				'file'       => 'cmsauth.log',
+				'level'      => 'info',
+				'format'     => "%datetime% %message%\n",
+				'dispatcher' => $dispatcher
 			));
 
 			$manager->register('spam', array(
-				'file' => 'cmsspam.log'
+				'file'       => 'cmsspam.log',
+				'dispatcher' => $dispatcher
 			));
 
 			return $manager;

--- a/src/Log/Manager.php
+++ b/src/Log/Manager.php
@@ -41,13 +41,6 @@ use Monolog\Logger as Monolog;
 class Manager
 {
 	/**
-	 * The application instance.
-	 *
-	 * @var  object
-	 */
-	protected $app;
-
-	/**
 	 * The registered log configs
 	 *
 	 * @var  array
@@ -72,18 +65,22 @@ class Manager
 		'format'      => '',
 		'level'       => 'debug',
 		'dateFormat'  => 'Y-m-d H:i:s',
-		'permissions' => 0640
+		'permissions' => 0640,
+		'dispatcher'  => null
 	);
 
 	/**
 	 * Create a new manager instance.
 	 *
-	 * @param   object  $app
+	 * @param   string  $path
 	 * @return  void
 	 */
-	public function __construct($app)
+	public function __construct($path = null)
 	{
-		$this->app = $app;
+		if ($path)
+		{
+			$this->defaults['path'] = (string) $path;
+		}
 	}
 
 	/**
@@ -143,20 +140,21 @@ class Manager
 
 			if (!$config['path'])
 			{
-				$config['path'] = $this->app['config']->get('log_path');
-				if (is_dir('/var/log/hubzero'))
-				{
-					$config['path'] = '/var/log/hubzero';
-				}
+				throw new InvalidArgumentException("Log path not specified for [$name].");
+			}
+
+			if (!$config['file'])
+			{
+				throw new InvalidArgumentException("Log file name not specified for [$name].");
 			}
 
 			$log = new Writer(
-				new Monolog($this->app['config']->get('application_env')),
-				$this->app['dispatcher']
+				new Monolog($name),
+				$config['dispatcher']
 			);
 
 			$log->useFiles(
-				$config['path'] . DS . $config['file'],
+				$config['path'] . DIRECTORY_SEPARATOR . $config['file'],
 				$config['level'],
 				$config['format'],
 				$config['dateFormat'],

--- a/src/Log/Writer.php
+++ b/src/Log/Writer.php
@@ -48,7 +48,7 @@ class Writer
 	 *
 	 * @var  object
 	 */
-	protected $monolog;
+	protected $monolog = null;
 
 	/**
 	 * All of the error levels.
@@ -71,7 +71,7 @@ class Writer
 	 *
 	 * @var  object
 	 */
-	protected $dispatcher;
+	protected $dispatcher = null;
 
 	/**
 	 * Create a new log writer instance.
@@ -94,7 +94,7 @@ class Writer
 	 * Call Monolog with the given method and parameters.
 	 *
 	 * @param   string  $method
-	 * @param   array  $parameters
+	 * @param   array   $parameters
 	 * @return  mixed
 	 */
 	protected function callMonolog($method, $parameters)
@@ -185,7 +185,7 @@ class Writer
 				return MonologLogger::EMERGENCY;
 
 			default:
-				throw new \InvalidArgumentException(\Lang::txt('Invalid log level.'));
+				throw new \InvalidArgumentException('Invalid log level.');
 		}
 	}
 
@@ -193,17 +193,17 @@ class Writer
 	 * Register a new callback handler for when
 	 * a log event is triggered.
 	 *
-	 * @param   object  $callback  Closure
+	 * @param   object  $handler  Closure
 	 * @return  void
 	 */
 	public function listen($handler)
 	{
-		if (!isset($this->dispatcher))
+		if (!($this->dispatcher instanceof DispatcherInterface))
 		{
-			throw new \RuntimeException(\Lang::txt('Events dispatcher has not been set.'));
+			throw new \RuntimeException('Event dispatcher has not been set.');
 		}
 
-		$this->dispatcher->register('onLog', $handler);
+		$this->dispatcher->addListener($handler, 'onLog');
 	}
 
 	/**
@@ -219,7 +219,7 @@ class Writer
 	/**
 	 * Get the event dispatcher instance.
 	 *
-	 * @return  object
+	 * @return  mixed  object or null
 	 */
 	public function getEventDispatcher()
 	{
@@ -229,7 +229,7 @@ class Writer
 	/**
 	 * Set the event dispatcher instance.
 	 *
-	 * @param   object
+	 * @param   object  $dispatcher
 	 * @return  void
 	 */
 	public function setEventDispatcher($dispatcher)
@@ -250,9 +250,9 @@ class Writer
 		// If the event dispatcher is set, we will pass along the parameters to the
 		// log listeners. These are useful for building profilers or other tools
 		// that aggregate all of the log messages for a given "request" cycle.
-		if (isset($this->dispatcher))
+		if ($this->dispatcher instanceof DispatcherInterface)
 		{
-			$this->dispatcher->trigger('system.onLog', array($level, $message, $context));
+			$this->dispatcher->trigger('onLog', array($level, $message, $context));
 		}
 	}
 
@@ -274,6 +274,6 @@ class Writer
 			return $this->callMonolog($method, $parameters);
 		}
 
-		throw new \BadMethodCallException(\Lang::txt('Method [%s] does not exist.', $method));
+		throw new \BadMethodCallException(sprintf('Method [%s] does not exist.', $method));
 	}
 }


### PR DESCRIPTION
Rather than passing the entire App object to the Manager class, we now
only pass an option default log path and optionally set a dispatcher
for the individual config of each logger (rather than assuming the
dispatcher set on the App object).