### PR TITLE
Namespace fix and update to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.4.0",
         "symfony/yaml": "2.5.*",
         "symfony/http-foundation": "2.5.5",
-        "composer/composer": "1.6.2"
+        "composer/composer": "1.6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",
@@ -16,7 +16,6 @@
         "squizlabs/php_codesniffer": "2.*",
         "jakub-onderka/php-parallel-lint": "0.9.*",
         "hubzero/standards": "dev-master",
-        "composer/composer": "1.6.2",
         "mockery/mockery": "0.9.*"
     },
     "repositories": [

--- a/src/Console/Command/Extension.php
+++ b/src/Console/Command/Extension.php
@@ -139,7 +139,7 @@ class Extension extends Base implements CommandInterface
 	 **/
 	private function alter($method)
 	{
-		$migration = new Migration(App::get('db'));
+		$migration = new Migration(\App::get('db'));
 
 		$name = null;
 		if ($this->arguments->getOpt('name'))


### PR DESCRIPTION
`muse extension <command>` was broken, not able to find App.

composer/composer had a fix submitted in 1.6.3 that we need (dealing with URL generation for Gitlab packages)