### PR TITLE
Bumping memory limit on single script

### DIFF
--- a/src/Utility/Composer.php
+++ b/src/Utility/Composer.php
@@ -117,6 +117,7 @@ class Composer
 	private static function _init()
 	{
 		//Set environment up for composer
+		ini_set('memory_limit', '1024M');
 		if (getenv('COMPOSER_HOME') != PATH_APP)
 		{
 			putenv('COMPOSER_HOME=' . PATH_APP);


### PR DESCRIPTION
Solving the dependency graph problem takes a lot of memory, so when
invoking composer we need more memory.

Refs: https://github.com/composer/composer/issues/5915