### PR TITLE
[fix] List languages for specified client

### DIFF
--- a/src/Form/Fields/Language.php
+++ b/src/Form/Fields/Language.php
@@ -59,6 +59,13 @@ class Language extends Select
 			$client = 'site';
 		}
 
+		$client_id = 0;
+
+		if ($client == 'administrator')
+		{
+			$client_id = 1;
+		}
+
 		$path = PATH_APP . DS . 'bootstrap' . DS . $client;
 		if (!is_dir($path))
 		{
@@ -68,7 +75,7 @@ class Language extends Select
 		// Merge any additional options in the XML definition.
 		$options = array_merge(
 			parent::getOptions(),
-			App::get('language')->getList($this->value, $path, true, true)
+			App::get('language')->getList($this->value, $path, true, true, $client_id)
 		);
 
 		return $options;

--- a/src/Language/Translator.php
+++ b/src/Language/Translator.php
@@ -1332,9 +1332,10 @@ class Translator extends Obj
 	 * @param   string   $basePath        Base path to use
 	 * @param   boolean  $caching         True if caching is used
 	 * @param   array    $installed       An array of arrays (text, value, selected)
+	 * @param   integer  $client          Client ID
 	 * @return  array    List of system languages
 	 */
-	public static function getList($actualLanguage, $basePath = PATH_APP, $caching = false, $installed = false)
+	public static function getList($actualLanguage, $basePath = PATH_APP, $caching = false, $installed = false, $client = null)
 	{
 		$list = array();
 
@@ -1349,9 +1350,8 @@ class Translator extends Obj
 				->whereEquals('type', 'language')
 				->whereEquals('state', 0)
 				->whereEquals('enabled', 1)
-				->whereEquals('client_id', \App::get('client')->id);
+				->whereEquals('client_id', (is_null($client) ? \App::get('client')->id : (int)$client));
 			$db->setQuery($query->toString());
-
 			$installed_languages = $db->loadObjectList('element');
 		}
 


### PR DESCRIPTION
The `getList()` method on Translator would always default to the
current client. These changes allow fo specifying a specific client,
defaulting to old behavior if no client is specified. Fixes issue with
specifying available languages for users for 'site' client.