### PR TITLE
[fix] Make sure non-existent components throw 404

### DIFF
--- a/src/Api/Component/Loader.php
+++ b/src/Api/Component/Loader.php
@@ -73,7 +73,7 @@ class Loader extends Base
 		$controllerClass = '\\Hubzero\\Component\\ApiController';
 
 		// Make sure the component is enabled
-		if ($this->isEnabled($option))
+		if ($this->isEnabled($option) && is_dir($this->path($option)))
 		{
 			// Set path and constants
 			define('PATH_COMPONENT', $this->path($option) . DIRECTORY_SEPARATOR . $client);


### PR DESCRIPTION
This fixes an issue where visiting the api url for a non-existent
component would still assume the component did exist and result in a 500