### PR TITLE
[fix] Don't try to list too many packages

### DIFF
--- a/src/Utility/Composer.php
+++ b/src/Utility/Composer.php
@@ -456,10 +456,17 @@ class Composer
 		$remotePackages = array();
 		foreach ($remoteRepos as $repo)
 		{
-			$packages = $repo->getPackages();
-			foreach ($packages as $package)
+			if (method_exists($repo, "getRepoConfig"))
 			{
-				$remotePackages[$package->getName()] = $package;
+				$config = $repo->getRepoConfig();
+				if (is_array($config) && isset($config['type']) && $config['type'] != 'composer')
+				{
+					$packages = $repo->getPackages();
+					foreach ($packages as $package)
+					{
+						$remotePackages[$package->getName()] = $package;
+					}
+				}
 			}
 		}
 		return $remotePackages;


### PR DESCRIPTION
When packagist is enabled, we can't list *all* available packages.
This should check to ensure we're not attempting to do that.