### PR TITLE
[refactor] Count query only selects a count

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -171,6 +171,18 @@ class Query
 	}
 
 	/**
+	 * Empties a query of current select values
+	 *
+	 * @return  $this
+	 * @since   2.2.2
+	 **/
+	public function deselect()
+	{
+		$this->syntax->resetSelect();
+		return $this;
+	}
+
+	/**
 	 * Applies a select field to the pending query
 	 *
 	 * @param   string  $column  The column to select
@@ -438,7 +450,7 @@ class Query
 	}
 
 	/**
-	 * Applies order by clause
+	 * Applies 'order by' clause
 	 *
 	 * @param   string  $column  The column to which the order by will apply
 	 * @param   string  $dir     The direction in which the results will be ordered
@@ -448,6 +460,18 @@ class Query
 	public function order($column, $dir)
 	{
 		$this->syntax->setOrder($column, $dir);
+		return $this;
+	}
+
+	/**
+	 * Removes 'order by' clause
+	 *
+	 * @return  $this
+	 * @since   2.0.0
+	 **/
+	public function unorder()
+	{
+		$this->syntax->resetOrder();
 		return $this;
 	}
 

--- a/src/Database/Relational.php
+++ b/src/Database/Relational.php
@@ -1040,9 +1040,15 @@ class Relational implements \IteratorAggregate, \ArrayAccess, \Serializable
 	public function total()
 	{
 		// Note that we do not need to parse includes at this stage, as includes do not effect
-		// the primary result set, and thus do not effect the count.  whereRelated could effect
+		// the primary result set, and thus do not effect the count. whereRelated() could effect
 		// the count, but that method is not currently in use.
-		$first = $this->select($this->getQualifiedFieldName($this->getPrimaryKey()), 'count', true)
+		//
+		// We also reset the 'select' clause to avoid pulling unnecessary records and reset
+		// the 'order by' clause to avoid referenced fields in the aforementioned 'select' clauses
+		// that mgiht have been removed. Neither of these should have any effect on a count.
+		$first = $this->deselect()
+		              ->select($this->getQualifiedFieldName($this->getPrimaryKey()), 'count', true)
+		              ->unordered()
 		              ->rows(false)
 		              ->first();
 		              //->count;
@@ -1733,6 +1739,19 @@ class Relational implements \IteratorAggregate, \ArrayAccess, \Serializable
 		// Set state for future use
 		$this->setState('orderby', $this->orderBy);
 		$this->setState('orderdir', $this->orderDir);
+
+		return $this;
+	}
+
+	/**
+	 * Unsets the ordering
+	 *
+	 * @return  $this
+	 * @since   2.2.2
+	 **/
+	public function unordered()
+	{
+		$this->unorder();
 
 		return $this;
 	}

--- a/src/Database/Syntax/Mysql.php
+++ b/src/Database/Syntax/Mysql.php
@@ -110,6 +110,17 @@ class Mysql
 	}
 
 	/**
+	 * Empty select values
+	 *
+	 * @return  void
+	 * @since   2.2.2
+	 **/
+	public function resetSelect()
+	{
+		$this->select = [];
+	}
+
+	/**
 	 * Sets a select element on the query
 	 *
 	 * @param   string  $column  The column to select
@@ -124,7 +135,7 @@ class Mysql
 		// This wouldn't get rid of table.* as that is likely added intentionally
 		if (isset($this->select[0]) && $this->select[0]['column'] == '*')
 		{
-			$this->select = [];
+			$this->resetSelect();
 		}
 
 		$this->select[] = [
@@ -389,6 +400,17 @@ class Mysql
 			'column' => $column,
 			'dir'    => $dir
 		];
+	}
+
+	/**
+	 * Resets an order element on the query
+	 *
+	 * @return  void
+	 * @since   2.2.2
+	 **/
+	public function resetOrder()
+	{
+		$this->order = [];
 	}
 
 	/**


### PR DESCRIPTION
When calling `paginated()` on a query, the cloned query used for
generating a record total would include all the `select` values, meaning
the query would return not just a count but also all the records. This
now clears all previous select values so it only returns the count.