### PR TITLE
Be consistent in calling a command

### DIFF
--- a/src/Console/Command/App/Package.php
+++ b/src/Console/Command/App/Package.php
@@ -65,7 +65,7 @@ class Package extends Base implements CommandInterface
 	 **/
 	public function show()
 	{
-		$package = $this->arguments->getOpt(3) ? $this->arguments->getOpt(3) : $this->arguments->getOpt('package');
+		$package = $this->arguments->getOpt('package');
 		if (!empty($package))
 		{
 			$versions = Composer::findRemotePackages($package, '*');
@@ -87,7 +87,7 @@ class Package extends Base implements CommandInterface
 	 **/
 	public function available()
 	{
-		$package = $this->arguments->getOpt(3) ? $this->arguments->getOpt(3) : $this->arguments->getOpt('package');
+		$package = $this->arguments->getOpt('package');
 		if (!empty($package))
 		{
 			$versions = Composer::findRemotePackages($package, '*');
@@ -142,7 +142,7 @@ class Package extends Base implements CommandInterface
 	 **/
 	public function update()
 	{
-		$package = $this->arguments->getOpt(3);
+		$package = $this->arguments->getOpt('package');
 		if (empty($package))
 		{
 			$this->output->error('A package name is required');
@@ -161,7 +161,7 @@ class Package extends Base implements CommandInterface
 	 **/
 	public function remove()
 	{
-		$package = $this->arguments->getOpt(3);
+		$package = $this->arguments->getOpt('package');
 		if (empty($package))
 		{
 			$this->output->error('A package name is required');


### PR DESCRIPTION
Have app commands all *only* accept '--package=' style arguments, some
allowed simply adding a package name as the final argument and some did
not, and some only accepted it as the final argument.