### PR TITLE
[fix] Try to catch EXIF read errors

### DIFF
--- a/src/Image/Processor.php
+++ b/src/Image/Processor.php
@@ -223,7 +223,14 @@ class Processor extends Obj
 
 		if ($this->image_type == IMAGETYPE_JPEG)
 		{
-			$this->exif_data = exif_read_data($this->source);
+			try
+			{
+				$this->exif_data = exif_read_data($this->source);
+			}
+			catch (Exception $e)
+			{
+				$this->exif_data = array();
+			}
 			if (isset($this->exif_data['Orientation']))
 			{
 				switch ($this->exif_data['Orientation'])
@@ -468,7 +475,14 @@ class Processor extends Obj
 			return false;
 		}
 
-		$this->exif_data = exif_read_data($this->source);
+		try
+		{
+			$this->exif_data = exif_read_data($this->source);
+		}
+		catch (Exception $e)
+		{
+			$this->exif_data = array();
+		}
 
 		if (isset($this->exif_data['GPSLatitude']))
 		{


### PR DESCRIPTION
PHP 5.6 has issues reading EXIF data, so try to catch any errors
thrown and proceed a little mroe gracefully.

Refs: https://bugs.php.net/bug.php?id=72914
Refs: https://bugs.php.net/bug.php?id=72819
Fixes: https://smarteragriculture.org/support/ticket/232