### PR TITLE
[fix] Fixing misnamed var

### DIFF
--- a/src/Auth/Link.php
+++ b/src/Auth/Link.php
@@ -394,7 +394,7 @@ class Link extends Relational
 	 */
 	public static function delete_by_user_id($user_id = null)
 	{
-		if (empty($uid))
+		if (empty($user_id))
 		{
 			return true;
 		}


### PR DESCRIPTION
This could caus entries to not be properly deleted which, in turn,
breaks account linking.