### PR TITLE
[feat] Adding helpers for displaying core SVG icons

### DIFF
--- a/src/Html/Builder/Asset.php
+++ b/src/Html/Builder/Asset.php
@@ -360,4 +360,44 @@ class Asset
 			}
 		}
 	}
+
+	/**
+	 * Load an icon's SVG representation
+	 *
+	 * @param   string  $method
+	 * @param   array   $parameters
+	 * @return  string
+	 */
+	public static function icon($symbol, $ariahidden = true)
+	{
+		$paths = array();
+		if (App::has('template'))
+		{
+			$paths[] = App::get('template')->path . '/html/icons/' . $symbol . '.svg';
+		}
+		$paths[] = PATH_CORE . '/assets/icons/' . $symbol . '.svg';
+
+		$content = '';
+
+		foreach ($paths as $path)
+		{
+			if (file_exists($path))
+			{
+				$atts = array(
+					'class="icn icn-' . $symbol . '"'
+				);
+
+				if ($ariahidden)
+				{
+					$atts[] = 'aria-hidden="true" focusable="false"';
+				}
+
+				$content = '<span ' . implode(' ', $atts) . '>' . file_get_contents($path) . '</span>';
+
+				break;
+			}
+		}
+
+		return $content;
+	}
 }

--- a/src/View/Helper/Icon.php
+++ b/src/View/Helper/Icon.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * HUBzero CMS
+ *
+ * Copyright 2005-2015 HUBzero Foundation, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * HUBzero is a registered trademark of Purdue University.
+ *
+ * @package   framework
+ * @author    Shawn Rice <zooley@purdue.edu>
+ * @copyright Copyright 2005-2015 HUBzero Foundation, LLC.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Hubzero\View\Helper;
+
+use Hubzero\Html\Builder\Asset;
+
+/**
+ * Helper for outputting icons.
+ */
+class Icon extends AbstractHelper
+{
+	/**
+	 * Generate asset path
+	 *
+	 * @param   string  $symbol
+	 * @param   bool    $ariahidden
+	 * @return  string
+	 */
+	public function __invoke($symbol, $ariahidden = true)
+	{
+		return Asset::icon($symbol, $ariahidden);
+	}
+}


### PR DESCRIPTION
These helpers take two arguments: a symbol name, and hide from screen
readers or not. Symbol name directly maps to a file representing the
desired icon. Icons are in `CORE/assets/icons` but can be overridden
with a `APP/templates/{template}/html/icons` directory.