### PR TITLE
[fix] Adjusting for PHP 5.6 to 7 compatibility

### DIFF
--- a/src/Error/Renderer/Api.php
+++ b/src/Error/Renderer/Api.php
@@ -74,7 +74,7 @@ class Api implements RendererInterface
 	 * @param   object  $exception
 	 * @return  void
 	 */
-	public function render(Exception $error)
+	public function render($error)
 	{
 		$status = $error->getCode() ? $error->getCode() : 500;
 		$status = ($status < 100 || $status >= 600) ? 500 : $status;

--- a/src/Error/Renderer/Notification.php
+++ b/src/Error/Renderer/Notification.php
@@ -65,7 +65,7 @@ class Notification implements RendererInterface
 	 * @param   object  $error  The exception for which to render the error page.
 	 * @return  void
 	 */
-	public function render(Exception $error)
+	public function render($error)
 	{
 		$this->notifier->message($error->getMessage(), ($error->getCode() == 500 ? 'error' : 'warning'));
 	}

--- a/src/Error/Renderer/Page.php
+++ b/src/Error/Renderer/Page.php
@@ -84,7 +84,7 @@ class Page implements RendererInterface
 	 * @param   object  $error  The exception for which to render the error page.
 	 * @return  void
 	 */
-	public function render(Exception $error)
+	public function render($error)
 	{
 		try
 		{

--- a/src/Error/Renderer/Plain.php
+++ b/src/Error/Renderer/Plain.php
@@ -66,7 +66,7 @@ class Plain implements RendererInterface
 	 * @param   object  $exception
 	 * @return  void
 	 */
-	public function render(Exception $error)
+	public function render($error)
 	{
 		if (!headers_sent())
 		{

--- a/src/Error/RendererInterface.php
+++ b/src/Error/RendererInterface.php
@@ -44,5 +44,5 @@ interface RendererInterface
 	 *
 	 * @param  object  $error
 	 */
-	public function render(Exception $error);
+	public function render($error);
 }


### PR DESCRIPTION
PHP 5.6 expects an object of type `Exception` whereas PHP 7 expects type
`Throwable`. To be compatible with both, we simply remove the type
hinting. May re-introduce once everything is on PHP 7.