### PR TITLE
[fix] Fixing issue with getting current run

### DIFF
--- a/src/Content/Import/Model/Import.php
+++ b/src/Content/Import/Model/Import.php
@@ -76,6 +76,13 @@ class Import extends Relational
 	public $orderDir = 'asc';
 
 	/**
+	 * Current run object
+	 *
+	 * @var  object
+	 */
+	protected $_currentRun = null;
+
+	/**
 	 * Fields and their validation criteria
 	 *
 	 * @var  array
@@ -123,10 +130,15 @@ class Import extends Relational
 	 */
 	public function currentRun()
 	{
-		return $this->runs()
-			->whereEquals('import_id', $this->get('id'))
-			->ordered()
-			->row();
+		if (!$this->_currentRun)
+		{
+			$this->_currentRun = $this->runs()
+				->whereEquals('import_id', $this->get('id'))
+				->ordered()
+				->row();
+		}
+
+		return $this->_currentRun;
 	}
 
 	/**


### PR DESCRIPTION
This fixes an issue where the import record could inadvertently get
a new Run record each time `currentRun()` was called, causing the
`processed` field to never be incremented.