### PR TITLE
[fix] Compatibility issue with PHP 7.2

### DIFF
--- a/src/Password/CharacterClass.php
+++ b/src/Password/CharacterClass.php
@@ -67,7 +67,7 @@ class CharacterClass
 	 * @param   string  $char
 	 * @return  object
 	 */
-	public static function match($char = null)
+	public static function match($char = '')
 	{
 		$result = array();
 
@@ -81,7 +81,7 @@ class CharacterClass
 			return $result;
 		}
 
-		if (count($char) == 0)
+		if (empty($char))
 		{
 			$char = chr(0);
 		}


### PR DESCRIPTION
Only arrays and objects that implement countable are countable in 7.2.

http://us3.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types