### PR TITLE
[refactor] Use PhpSpreadsheet instead of PhpExcel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "php": ">=5.4.0",
         "symfony/yaml": "2.5.*",
         "symfony/http-foundation": "2.5.5",
-        "composer/composer": "1.6.3"
+        "composer/composer": "1.6.3",
+        "phpoffice/phpspreadsheet": "1.4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
This adds the PhpSpreadsheet library (moved from hubzero-cms) and updates the Excel importer adapter to use it.