### PR TITLE
[fix] Use root instead of base

### DIFF
--- a/src/Html/Toolbar/Button/Popup.php
+++ b/src/Html/Toolbar/Button/Popup.php
@@ -103,7 +103,7 @@ class Popup extends Button
 	{
 		if (substr($url, 0, 4) !== 'http')
 		{
-			$url = rtrim(\Request::base(), '/') . '/' . ltrim($url, '/');
+			$url = rtrim(\Request::root(), '/') . '/' . ltrim($url, '/');
 		}
 
 		return $url;


### PR DESCRIPTION
Using `Request::base()` works fine for master, where the admin directory
no longer exists. Base and root are the same in that case. But, on 2.2
where the admin directory still exists, this can cause 'administrator'
to appear twice in the URL (due to being passed through `Route::url()`).

Fixes: https://purr.purdue.edu/support/ticket/1966