### PR TITLE
Refactor sanitize

### DIFF
--- a/src/Utility/Sanitize.php
+++ b/src/Utility/Sanitize.php
@@ -426,7 +426,7 @@ class Sanitize
 
 		$elementSettings = [$styleElement, $mapElement, $areaElement];
 
-		foreach($elementSettings as $settings)
+		foreach ($elementSettings as $settings)
 		{
 			$element = $htmlPurifierWhitelist->addElement(
 				$settings['name'],


### PR DESCRIPTION
I'd like to extract the steps below from the Sanitize::html function to an HTML purifier factory class, but I'm unsure of where to put such a factory.

- Creation of the HTML purifier configuration
- Updating of the HTML purifier white list
- Creation of the HTML purifier

[Single Responsibility Principle](https://en.wikipedia.org/wiki/Single_responsibility_principle)