### PR TITLE
[fix] Fix moving files for Google Drive

### DIFF
--- a/src/Filesystem/Entity.php
+++ b/src/Filesystem/Entity.php
@@ -502,7 +502,7 @@ class Entity extends Obj
 	 **/
 	public function move($to)
 	{
-		$dest   = $to . '/' . $this->getName();
+		$dest   = $to . '/' . $this->getDisplayName() . '.' . $this->getExtension();
 		$return = $this->hasAdapterOrFail()->adapter->rename($this->getPath(), $dest);
 
 		// Update the internal path


### PR DESCRIPTION
This change ensures the new filename has a name and extension (getName
only returns the name without extension from Google Drive adapter)