### PR TITLE
[fix] Temporarily removing firebase/php-jwt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
         "symfony/yaml": "2.5.*",
         "symfony/http-foundation": "2.5.5",
         "composer/composer": "1.6.3",
-        "phpoffice/phpspreadsheet": "1.4.1",
-        "firebase/php-jwt": "5.0.0"
+        "phpoffice/phpspreadsheet": "1.4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
This was requiring v5 which was conflicting with v4 used by the Google
API package that is required by the CMS.