### PR TITLE
[fix] Ensure array of nested objects is converted to array

### DIFF
--- a/src/Search/Adapters/SolrIndexAdapter.php
+++ b/src/Search/Adapters/SolrIndexAdapter.php
@@ -211,9 +211,9 @@ class SolrIndexAdapter implements IndexInterface
 		$newDoc = $update->createDocument();
 		foreach ($document as $field => $value)
 		{
-			if (is_array($value))
+			if (!is_string($value))
 			{
-				$newDoc->$field = $value;
+				$newDoc->$field = json_decode(json_encode($value), true);
 			}
 			else
 			{


### PR DESCRIPTION
Solarium was expecting a nest of arrays, so this method
will convert objects to arrays.