### PR TITLE
[refactor] Add session store getter and use it

### DIFF
--- a/src/Session/Helper.php
+++ b/src/Session/Helper.php
@@ -64,7 +64,7 @@ class Helper
 	 */
 	public static function getSession($id)
 	{
-		return self::storage()->session($id);
+		return \App::get('session')->getStore()->session($id);
 	}
 
 	/**
@@ -76,7 +76,7 @@ class Helper
 	public static function getSessionWithUserId($userid)
 	{
 		// get list of all sessions
-		$sessions = self::storage()->all(array(
+		$sessions = \App::get('session')->getStore()->all(array(
 			'guest'    => 0,
 			'distinct' => 1
 		));
@@ -102,6 +102,6 @@ class Helper
 	 */
 	public static function getAllSessions($filters = array())
 	{
-		return self::storage()->all($filters);
+		return \App::get('session')->getStore()->all();
 	}
 }

--- a/src/Session/Manager.php
+++ b/src/Session/Manager.php
@@ -188,6 +188,16 @@ class Manager extends Obj
 	}
 
 	/**
+	 * Get session store object
+	 *
+	 * @return	object	The session store object
+	 */
+	public function getStore()
+	{
+		return $this->store;
+	}
+
+	/**
 	 * Get expiration time in minutes
 	 *
 	 * @return  integer  The session expiration time in minutes


### PR DESCRIPTION
Previous helper method would end up invoking __construct on the
configured session store causing an error in PHP 7.2.  This uses the
already instantiated session store.