### PR TITLE
[fix] Ensure variable is not false

### DIFF
--- a/src/Search/Adapters/SolrQueryAdapter.php
+++ b/src/Search/Adapters/SolrQueryAdapter.php
@@ -398,6 +398,10 @@ class SolrQueryAdapter implements QueryInterface
 			$accessFilter = "(access_level:public) OR (access_level:registered) " . $userFilter;
 
 			$userGroups = \Hubzero\User\Helper::getGroups($user);
+			if (!$userGroups)
+			{
+				$userGroups = array();
+			}
 			$userGroups = array_map(function($group){
 				return $group->gidNumber;
 			}, $userGroups);


### PR DESCRIPTION
The user group helper returns false in the case of an empty set,
array_map expects an array.