### PR TITLE
[fix] Moving to CMS composer due to  dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
         "symfony/yaml": "2.5.*",
         "symfony/http-foundation": "2.5.5",
         "composer/composer": "1.6.3",
-        "firebase/php-jwt": "5.0.0",
         "phpoffice/phpspreadsheet": "1.4.1"
     },
     "require-dev": {


### PR DESCRIPTION
The JWT library is being moved to the master branch of the CMS which has
a dependency of PHP 7. The current production branch of 2.2 has a
dependency of php 5.6 which causes composer to not be able to resolve
an installable set of packages.