### PR TITLE
[fix] Don't log 404s and 403s

### DIFF
--- a/src/Error/Handler.php
+++ b/src/Error/Handler.php
@@ -180,7 +180,7 @@ class Handler
 	 */
 	public function handleException($exception)
 	{
-		if (is_object($this->logger))
+		if (is_object($this->logger) && !in_array($exception->getCode(), [403, 404]))
 		{
 			$this->logger->log(
 				'error',


### PR DESCRIPTION
This fills up logs pretty fast. Especially with bots crawling things.