### PR TITLE
[feat] Adding driver and syntax for MariaDB

### DIFF
--- a/src/Database/Driver/Mariadb.php
+++ b/src/Database/Driver/Mariadb.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * HUBzero
+ *
+ * @package    framework
+ * @copyright  Copyright 2005-2019 HUBzero Foundation, LLC.
+ * @license    http://opensource.org/licenses/MIT MIT
+ * @since      Class available since release 2.2.15
+ */
+
+namespace Hubzero\Database\Driver;
+
+/**
+ * MariaDB (Pdo) database driver
+ *
+ * MariaDB is a fork of MySQL and, for now, should
+ * support everything in the MySQL driver.
+ */
+class Mariadb extends Mysql
+{
+}

--- a/src/Database/Syntax/Mariadb.php
+++ b/src/Database/Syntax/Mariadb.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * HUBzero
+ *
+ * @package    framework
+ * @copyright  Copyright 2005-2019 HUBzero Foundation, LLC.
+ * @license    http://opensource.org/licenses/MIT MIT
+ * @since      Class available since release 2.2.15
+ */
+
+namespace Hubzero\Database\Syntax;
+
+/**
+ * Database MariaDB query syntax class
+ *
+ * MariaDB is a fork of MySQL and, for now, should
+ * employ the same syntax.
+ */
+class Mariadb extends Mysql
+{
+}


### PR DESCRIPTION
MariaDB is a fork of MySQL and is compatible with MySQL's syntax. So,
until it deviates or custom functionality is needed, it just extends the
MySQL classes.