### PR TITLE
[refactor] Handle datetime col default being null

### DIFF
--- a/src/Activity/Recipient.php
+++ b/src/Activity/Recipient.php
@@ -97,7 +97,8 @@ class Recipient extends Relational
 	 */
 	public function wasViewed()
 	{
-		if ($this->get('viewed', '0000-00-00 00:00:00') != '0000-00-00 00:00:00')
+		if ($this->get('viewed')
+		 && $this->get('viewed') != '0000-00-00 00:00:00')
 		{
 			return true;
 		}
@@ -126,7 +127,7 @@ class Recipient extends Relational
 	 */
 	public function markAsNotViewed()
 	{
-		$this->set('viewed', '0000-00-00 00:00:00');
+		$this->set('viewed', null);
 
 		return $this->save();
 	}

--- a/src/Item/Announcement.php
+++ b/src/Item/Announcement.php
@@ -142,7 +142,7 @@ class Announcement extends Relational
 	{
 		if (!isset($data['publish_down']) || !$data['publish_down'])
 		{
-			$data['publish_down'] = '0000-00-00 00:00:00';
+			$data['publish_down'] = null;
 		}
 		return $data['publish_down'];
 	}


### PR DESCRIPTION
Minor changes to handle datetime columns default value being `null` (in
compliance with MySQL strict mode).