### PR TITLE
[refactor] Updating travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ php:
   - 5.6
   - 7.0
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 before_install: composer self-update
 
-install: composer install --prefer-source --no-interaction
+install: composer install --prefer-dist --no-interaction
 
 script:
   - mkdir -p build/logs


### PR DESCRIPTION
Caching the composer dependencies should reduce build time, and
prefer-dist should reduce the build size by not grabbing the full source
for all dependencies