### PR TITLE
[feat] Adding `join` helpers and `clear` method

### DIFF
--- a/src/Database/Exception/UnsupportedSyntaxException.php
+++ b/src/Database/Exception/UnsupportedSyntaxException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package   framework
+ * @copyright Copyright 2005-2019 HUBzero Foundation, LLC.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Hubzero\Database\Exception;
+
+class UnsupportedSyntaxException extends \Hubzero\Error\Exception\RuntimeException
+{
+}

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -171,6 +171,29 @@ class Query
 	}
 
 	/**
+	 * Empties a query clause of current values
+	 *
+	 * @param   string  $clause  [select, update, insert, delete, from, join, set, values, where, group, having, order]
+	 * @return  $this
+	 * @since   2.2.15
+	 **/
+	public function clear($clause = '')
+	{
+		if (!$clause)
+		{
+			$this->reset();
+		}
+		else
+		{
+			$clause = 'reset' . ucfirst(strtolower($clause));
+
+			$this->syntax->$clause();
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Empties a query of current select values
 	 *
 	 * @return  $this
@@ -280,6 +303,62 @@ class Query
 	public function joinRaw($table, $raw, $type = 'inner')
 	{
 		$this->syntax->setRawJoin($table, $raw, $type);
+		return $this;
+	}
+
+	/**
+	 * Defines a table INNER join to be performed for the query
+	 *
+	 * @param   string  $table     The table join
+	 * @param   string  $leftKey   The left side of the join condition
+	 * @param   string  $rightKey  The right side of the join condition
+	 * @return  $this
+	 **/
+	public function innerJoin($table, $leftKey, $rightKey)
+	{
+		$this->syntax->setJoin($table, $leftKey, $rightKey, 'inner');
+		return $this;
+	}
+
+	/**
+	 * Defines a table FULL OUTER join to be performed for the query
+	 *
+	 * @param   string  $table     The table join
+	 * @param   string  $leftKey   The left side of the join condition
+	 * @param   string  $rightKey  The right side of the join condition
+	 * @return  $this
+	 **/
+	public function fullJoin($table, $leftKey, $rightKey)
+	{
+		$this->syntax->setJoin($table, $leftKey, $rightKey, 'full');
+		return $this;
+	}
+
+	/**
+	 * Defines a table LEFT join to be performed for the query
+	 *
+	 * @param   string  $table     The table join
+	 * @param   string  $leftKey   The left side of the join condition
+	 * @param   string  $rightKey  The right side of the join condition
+	 * @return  $this
+	 **/
+	public function leftJoin($table, $leftKey, $rightKey)
+	{
+		$this->syntax->setJoin($table, $leftKey, $rightKey, 'left');
+		return $this;
+	}
+
+	/**
+	 * Defines a table RIGHT join to be performed for the query
+	 *
+	 * @param   string  $table     The table join
+	 * @param   string  $leftKey   The left side of the join condition
+	 * @param   string  $rightKey  The right side of the join condition
+	 * @return  $this
+	 **/
+	public function rightJoin($table, $leftKey, $rightKey)
+	{
+		$this->syntax->setJoin($table, $leftKey, $rightKey, 'right');
 		return $this;
 	}
 

--- a/src/Database/Syntax/Mysql.php
+++ b/src/Database/Syntax/Mysql.php
@@ -160,6 +160,18 @@ class Mysql
 	}
 
 	/**
+	 * Empty insert values
+	 *
+	 * @return  void
+	 * @since   2.2.15
+	 **/
+	public function resetInsert()
+	{
+		$this->insert = '';
+		$this->ignore = false;
+	}
+
+	/**
 	 * Sets an update element on the query
 	 *
 	 * @param   string  $table  The table whose fields will be updated
@@ -172,6 +184,17 @@ class Mysql
 	}
 
 	/**
+	 * Empty update values
+	 *
+	 * @return  void
+	 * @since   2.2.15
+	 **/
+	public function resetUpdate()
+	{
+		$this->update = '';
+	}
+
+	/**
 	 * Sets a delete element on the query
 	 *
 	 * @param   string  $table  The table whose row will be deleted
@@ -181,6 +204,17 @@ class Mysql
 	public function setDelete($table)
 	{
 		$this->delete = $table;
+	}
+
+	/**
+	 * Empty update values
+	 *
+	 * @return  void
+	 * @since   2.2.15
+	 **/
+	public function resetDelete()
+	{
+		$this->delete = '';
 	}
 
 	/**
@@ -197,6 +231,17 @@ class Mysql
 			'table' => $table,
 			'as'    => $as
 		];
+	}
+
+	/**
+	 * Empty from values
+	 *
+	 * @return  void
+	 * @since   2.2.15
+	 **/
+	public function resetFrom()
+	{
+		$this->from = [];
 	}
 
 	/**
@@ -217,6 +262,17 @@ class Mysql
 			'right' => $rightKey,
 			'type'  => $type
 		];
+	}
+
+	/**
+	 * Empty join values
+	 *
+	 * @return  void
+	 * @since   2.2.15
+	 **/
+	public function resetJoin()
+	{
+		$this->join = [];
 	}
 
 	/**
@@ -249,6 +305,17 @@ class Mysql
 	}
 
 	/**
+	 * Empty join values
+	 *
+	 * @return  void
+	 * @since   2.2.15
+	 **/
+	public function resetSet()
+	{
+		$this->set = [];
+	}
+
+	/**
 	 * Sets a values element on the query
 	 *
 	 * @param   array  $data  The data to be inserted
@@ -261,6 +328,17 @@ class Mysql
 	}
 
 	/**
+	 * Empty values
+	 *
+	 * @return  void
+	 * @since   2.2.15
+	 **/
+	public function resetValues()
+	{
+		$this->values = [];
+	}
+
+	/**
 	 * Sets a group element on the query
 	 *
 	 * @param   string  $column  The column on which to apply the group by
@@ -270,6 +348,17 @@ class Mysql
 	public function setGroup($column)
 	{
 		$this->group[] = $column;
+	}
+
+	/**
+	 * Empty group values
+	 *
+	 * @return  void
+	 * @since   2.2.15
+	 **/
+	public function resetGroup()
+	{
+		$this->group = [];
 	}
 
 	/**
@@ -288,6 +377,17 @@ class Mysql
 			'operator' => $operator,
 			'value'    => $value
 		];
+	}
+
+	/**
+	 * Empty having values
+	 *
+	 * @return  void
+	 * @since   2.2.15
+	 **/
+	public function resetHaving()
+	{
+		$this->having = [];
 	}
 
 	/**
@@ -345,6 +445,17 @@ class Mysql
 			'resetdepth' => true,
 			'depth'      => $depth
 		];
+	}
+
+	/**
+	 * Empty where values
+	 *
+	 * @return  void
+	 * @since   2.2.15
+	 **/
+	public function resetWhere()
+	{
+		$this->where = [];
 	}
 
 	/**

--- a/src/Database/Syntax/Sqlite.php
+++ b/src/Database/Syntax/Sqlite.php
@@ -33,6 +33,8 @@
 
 namespace Hubzero\Database\Syntax;
 
+use Hubzero\Database\Exception\UnsupportedSyntaxException;
+
 /**
  * Database sqlite query syntax class
  */
@@ -47,6 +49,46 @@ class Sqlite extends Mysql
 	public function buildInsert()
 	{
 		return 'INSERT ' . (($this->ignore) ? 'OR IGNORE ' : '') . 'INTO ' . $this->connection->quoteName($this->insert);
+	}
+
+	/**
+	 * Sets a join element on the query
+	 *
+	 * @param   string  $table     The table join
+	 * @param   string  $leftKey   The left side of the join condition
+	 * @param   string  $rightKey  The right side of the join condition
+	 * @param   string  $type      The join type to perform
+	 * @return  void
+	 * @throws  Hubzero\Database\Exception\UnsupportedSyntaxException
+	 * @since   2.2.15
+	 **/
+	public function setJoin($table, $leftKey, $rightKey, $type = 'inner')
+	{
+		if (in_array($type, ['right', 'full', 'full outer']))
+		{
+			throw new UnsupportedSyntaxException('RIGHT and FULL OUTER JOINs are not currently supported for SQLite', 500);
+		}
+
+		parent::setJoin($table, $leftKey, $rightKey, $type);
+	}
+
+	/**
+	 * Sets a join element on the query
+	 *
+	 * @param   string  $table  The table join
+	 * @param   string  $raw    The join clause
+	 * @param   string  $type   The join type to perform
+	 * @throws  Hubzero\Database\Exception\UnsupportedSyntaxException
+	 * @return  $this
+	 **/
+	public function setRawJoin($table, $raw, $type = 'inner')
+	{
+		if (in_array($type, ['right', 'full', 'full outer']))
+		{
+			throw new UnsupportedSyntaxException('RIGHT and FULL OUTER JOINs are not currently supported for SQLite', 500);
+		}
+
+		parent::setRawJoin($table, $raw, $type);
 	}
 
 	/**

--- a/src/Database/Tests/QueryTest.php
+++ b/src/Database/Tests/QueryTest.php
@@ -266,6 +266,97 @@ class QueryTest extends Database
 	 *
 	 * @return  void
 	 **/
+	public function testBuildQueryWithJoinClause()
+	{
+		$dbo = $this->getMockDriver();
+
+		// Here's the query we're try to write...
+		$expected = "SELECT * FROM `users` INNER JOIN posts ON `users`.id = `posts`.user_id";
+
+		$query = new Query($dbo);
+		$query->select('*')
+		      ->from('users')
+		      ->join('posts', '`users`.id', '`posts`.user_id');
+
+		$this->assertEquals($expected, str_replace("\n", ' ', $query->toString()), 'join Query did not build the expected result');
+
+		$query = new Query($dbo);
+		$query->select('*')
+		      ->from('users')
+		      ->innerJoin('posts', '`users`.id', '`posts`.user_id');
+
+		$this->assertEquals($expected, str_replace("\n", ' ', $query->toString()), 'innerJoin Query did not build the expected result');
+
+		// Here's the query we're try to write...
+		$expected = "SELECT * FROM `users` LEFT JOIN posts ON `users`.id = `posts`.user_id";
+
+		$query = new Query($dbo);
+		$query->select('*')
+		      ->from('users')
+		      ->leftJoin('posts', '`users`.id', '`posts`.user_id');
+
+		$this->assertEquals($expected, str_replace("\n", ' ', $query->toString()), 'leftJoin Query did not build the expected result');
+
+		// Here's the query we're try to write...
+		$expected = "SELECT * FROM `users` RIGHT JOIN posts ON `users`.id = `posts`.user_id";
+
+		$query = new Query($dbo);
+
+		if ($dbo->getConnection()->getAttribute(\PDO::ATTR_DRIVER_NAME) == 'sqlite')
+		{
+			$this->setExpectedException('\Hubzero\Database\Exception\UnsupportedSyntaxException');
+
+			$query->select('*')
+			      ->from('users')
+			      ->rightJoin('posts', '`users`.id', '`posts`.user_id');
+		}
+		else
+		{
+			$query->select('*')
+			      ->from('users')
+			      ->rightJoin('posts', '`users`.id', '`posts`.user_id');
+
+			$this->assertEquals($expected, str_replace("\n", ' ', $query->toString()), 'rightJoin Query did not build the expected result');
+		}
+
+		// Here's the query we're try to write...
+		$expected = "SELECT * FROM `users` RIGHT JOIN posts ON `users`.id = `posts`.user_id";
+
+		$query = new Query($dbo);
+		$query->select('*')
+		      ->from('users')
+		      ->rightJoin('posts', '`users`.id', '`posts`.user_id');
+
+		$this->assertEquals($expected, str_replace("\n", ' ', $query->toString()), 'rightJoin Query did not build the expected result');
+
+		// Here's the query we're try to write...
+		$expected = "SELECT * FROM `users` FULL JOIN posts ON `users`.id = `posts`.user_id";
+
+		$query = new Query($dbo);
+
+		if ($dbo->getConnection()->getAttribute(\PDO::ATTR_DRIVER_NAME) == 'sqlite')
+		{
+			$this->setExpectedException('\Hubzero\Database\Exception\UnsupportedSyntaxException');
+
+			$query->select('*')
+			      ->from('users')
+			      ->fullJoin('posts', '`users`.id', '`posts`.user_id');
+		}
+		else
+		{
+			$query->select('*')
+			      ->from('users')
+			      ->fullJoin('posts', '`users`.id', '`posts`.user_id');
+
+			$this->assertEquals($expected, str_replace("\n", ' ', $query->toString()), 'fullJoin Query did not build the expected result');
+		}
+	}
+
+	/**
+	 * Test to make sure we can build a query with a raw JOIN statement
+	 *
+	 * @return  void
+	 **/
 	public function testBuildQueryWithRawJoinClause()
 	{
 		// Here's the query we're try to write...
@@ -339,5 +430,28 @@ class QueryTest extends Database
 		// If the result were not in the cache, we could get a false positive.
 		$query->fetch('rows', true);
 		$query->fetch('rows', true);
+	}
+
+	/**
+	 * Test to make sure we can build a query with where IS NULL statements
+	 *
+	 * @return  void
+	 **/
+	public function testBuildQueryClear()
+	{
+		// Here's the query we're try to write...
+		$expected = "SELECT * FROM `groups`";
+
+		$dbo   = $this->getMockDriver();
+		$query = new Query($dbo);
+
+		$query->select('*')
+		      ->from('users')
+		      ->whereIsNotNull('name')
+		      ->clear('from')
+		      ->clear('where')
+		      ->from('groups');
+
+		$this->assertEquals($expected, str_replace("\n", ' ', $query->toString()), 'Query did not build the expected result');
 	}
 }


### PR DESCRIPTION
* Adds shortcut helper methods in the query builder for the types of
  SQL joins that can be performed. Note: SQLite does not support right
  or full joins.
* Adds a `clear($clause)` method for resetting portions of a Query.