### PR TITLE
[fix] Add the root path to `/file/` URLs

### DIFF
--- a/src/Content/Moderator.php
+++ b/src/Content/Moderator.php
@@ -107,7 +107,7 @@ class Moderator
 	 **/
 	public function getUrl()
 	{
-		return '/files/' . $this->getIdentifier();
+		return App::get('request')->root(true) . 'files/' . $this->getIdentifier();
 	}
 
 	/**


### PR DESCRIPTION
In most cases, this won't change the URL. But, in some odd setups, such
as running a hub in a sub-directory, this fixes improper /files URLs.