### PR TITLE
[fix] check for file instead of class to prevent Facade fallback

### DIFF
--- a/src/Filesystem/Entity.php
+++ b/src/Filesystem/Entity.php
@@ -143,9 +143,10 @@ class Entity extends Obj
 		}
 
 		// If it's a file, do we have a more specialized class?
-		$class = __NAMESPACE__ . '\\Type\\' . ucfirst($properties['extension']);
-		if (class_exists($class))
+		$file = __DIR__ . '/Type/' . ucfirst($properties['extension']) . '.php';
+		if (file_exists($file))
 		{
+			$class = __NAMESPACE__ . '\\Type\\' . ucfirst($properties['extension']);
 			return new $class($properties, $adapter);
 		}
 


### PR DESCRIPTION
html files were incorrectly attempting to use Hubzero\Facade\Html
since it didn't correctly return false when checking for special
types.

fixes: https://qubeshub.org/support/tickets/1405