### PR TITLE
[fix] Pass full path to delete methods

### DIFF
--- a/src/Filesystem/Macro/EmptyDirectory.php
+++ b/src/Filesystem/Macro/EmptyDirectory.php
@@ -61,11 +61,11 @@ class EmptyDirectory extends Base
 		{
 			if ($item['type'] === 'dir')
 			{
-				$this->filesystem->deleteDirectory($item['path']);
+				$this->filesystem->deleteDirectory($dirname . $item['path']);
 			}
 			else
 			{
-				$this->filesystem->delete($item['path']);
+				$this->filesystem->delete($dirname . $item['path']);
 			}
 		}
 	}


### PR DESCRIPTION
Paths for items returned from `listContents` are relative to the base
path passed to that method. So, said base path needs to be prepended to
the paths passed to the delete methods for them to work.