### PR TITLE
[fix] Don't escape single quotes

### DIFF
--- a/src/Html/Toolbar/Button/Confirm.php
+++ b/src/Html/Toolbar/Button/Confirm.php
@@ -119,7 +119,7 @@ class Confirm extends Button
 		Behavior::framework();
 
 		$message = \Lang::txt('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
-		$message = addslashes($message);
+		$message = str_replace('"', '&quot;', $message);
 
 		return $message;
 	}


### PR DESCRIPTION
Escaping is unnecessary as text is no longer directly output to JS.

Fixes: https://habricentral.org/support/ticket/853