### PR TITLE
[fix] Backwards compatibility for redirect URIs

### DIFF
--- a/src/Plugin/OauthClient.php
+++ b/src/Plugin/OauthClient.php
@@ -75,14 +75,24 @@ abstract class OauthClient extends Plugin
 		$service = trim(\Request::base(), '/');
 
 		$task = 'login';
+		$option = 'login';
 
 		if (\App::isSite())
 		{
-			// If someone is logged in already, then we're linking an account
-			$task  = (\User::isGuest()) ? 'login' : 'link';
+			// Legacy support
+			if (\App::has('component') && \App::get('component')->isEnabled('com_users'))
+			{
+				// If someone is logged in already, then we're linking an account
+				$task   = (\User::isGuest()) ? 'user.login' : 'user.link';
+				$option = 'users';
+			}
+			else
+			{
+				$task   = (\User::isGuest()) ? 'login' : 'link';
+			}
 		}
 
-		$scope = '/index.php?option=com_login&task=' . $task . '&authenticator=' . $name;
+		$scope = '/index.php?option=com_' . $option . '&task=' . $task . '&authenticator=' . $name;
 
 		return $service . $scope;
 	}


### PR DESCRIPTION
If the old com_users exists, then use redirect URIs for it. Otherwise
go to com_login. This should provide time for updating 3rd party configs
until we're ready to remove com_users entirely.