### PR TITLE
[fix] Avoid web home page matching Cli client

### DIFF
--- a/src/Base/ClientDetector.php
+++ b/src/Base/ClientDetector.php
@@ -64,6 +64,16 @@ class ClientDetector
 		{
 			if ($client = ClientManager::client($environment, true))
 			{
+				if ($client->name == 'cli')
+				{
+					if (php_sapi_name() == 'cli')
+					{
+						return $client;
+					}
+
+					continue;
+				}
+
 				$const = 'JPATH_' . strtoupper($environment);
 
 				// To determine the current environment, we'll simply iterate through the possible


### PR DESCRIPTION
When on the home page, the URL segment is empty, which will match the
Cli client type. Cli should only ever be matched in the context of
being run from the command line.

Todo: Move client matching to a method on the client objects?