### PR TITLE
Allow muse commands to be run from components

### DIFF
--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -293,18 +293,15 @@ class Arguments
 			}
 
 			// Check for existence
-			if (!class_exists($namespace))
+			if (!class_exists($namespace) && !empty($paths))
 			{
-				if (!empty($paths))
+				foreach ($paths as $path)
 				{
-					foreach ($paths as $path)
+					$path = strtolower($path);
+					if (file_exists($path . '.php'))
 					{
-						$path = strtolower($path);
-						if (file_exists($path . '.php'))
-						{
-							require_once $path . '.php';
-							break;
-						}
+						require_once $path . '.php';
+						break;
 					}
 				}
 			}

--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -212,6 +212,7 @@ class Arguments
 	 * Registers a location to look for commands
 	 *
 	 * @param   string  $namespace  The namespace location to use
+	 * @param   array   $paths      Optional paths to load from
 	 * @return  $this
 	 **/
 	public static function registerNamespace($namespace, $paths = array())

--- a/src/Console/ArgumentsServiceProvider.php
+++ b/src/Console/ArgumentsServiceProvider.php
@@ -31,8 +31,13 @@ class ArgumentsServiceProvider extends Middleware
 
 			// Register namespace for App commands and component commands
 			// @FIXME: neither of these work yet...
-			Arguments::registerNamespace('\App\Commands');
-			Arguments::registerNamespace('\Components\{$1}\Cli\Commands');
+			Arguments::registerNamespace('\App\Commands', [
+				PATH_APP . '/commands',
+			]);
+			Arguments::registerNamespace('\Components\{$1}\Commands', [
+				PATH_APP . '/components/com_{$1}/commands',
+				PATH_CORE . '/components/com_{$1}/commands'
+			]);
 
 			return new Arguments($argv);
 		};

--- a/src/Console/ArgumentsServiceProvider.php
+++ b/src/Console/ArgumentsServiceProvider.php
@@ -30,14 +30,16 @@ class ArgumentsServiceProvider extends Middleware
 			global $argv;
 
 			// Register namespace for App commands and component commands
-			// @FIXME: neither of these work yet...
-			Arguments::registerNamespace('\App\Commands', [
-				PATH_APP . '/commands',
-			]);
-			Arguments::registerNamespace('\Components\{$1}\Commands', [
-				PATH_APP . '/components/com_{$1}/commands',
-				PATH_CORE . '/components/com_{$1}/commands'
-			]);
+			if (defined('PATH_APP'))
+			{
+				Arguments::registerNamespace('\App\Commands', [
+					PATH_APP . '/commands',
+				]);
+				Arguments::registerNamespace('\Components\{$1}\Commands', [
+					PATH_APP . '/components/com_{$1}/commands',
+					PATH_CORE . '/components/com_{$1}/commands'
+				]);
+			}
 
 			return new Arguments($argv);
 		};


### PR DESCRIPTION
Muse can now discover commands from components. Given:

`core/components/com_cron/commands/run.php`

Muse command:

`muse cron:run {task}`

Command pattern is `muse {component}:{command} {task} {options}`

A little ugly but necessary for prefixed extensions. Once all extensions
are unprefixed (e.g. `components/groups` instead of
`components/com_groups`), autoloading should take over and these new
lines won't be necessary.