### PR TITLE
pgsql dsn header length fixed

### DIFF
--- a/src/Database/Driver/Pgsql.php
+++ b/src/Database/Driver/Pgsql.php
@@ -54,7 +54,7 @@ class Pgsql extends PdoDriver
 			}
 		}
 
-		if (substr($options['dsn'], 0, 7) != 'pgsql:')
+		if (substr($options['dsn'], 0, 6) != 'pgsql:')
 		{
 			throw new ConnectionFailedException('Postgres DSN for PDO connection does not appear to be valid.', 500);
 		}


### PR DESCRIPTION
The validation of the PDO dsn string is incorrect, I assume was based on "sqlite:" (7 characters)